### PR TITLE
Display the speaker's talks in their profile

### DIFF
--- a/src/apollo/__generated__/types.ts
+++ b/src/apollo/__generated__/types.ts
@@ -26,6 +26,7 @@ export type QueryTalksArgs = {
   day?: Maybe<Scalars["String"]>;
   roomId?: Maybe<Scalars["ID"]>;
   talkType?: Maybe<TalkType>;
+  speakerId?: Maybe<Scalars["ID"]>;
 };
 
 export type QueryRoomArgs = {

--- a/src/apollo/__generated__/types.ts
+++ b/src/apollo/__generated__/types.ts
@@ -26,7 +26,6 @@ export type QueryTalksArgs = {
   day?: Maybe<Scalars["String"]>;
   roomId?: Maybe<Scalars["ID"]>;
   talkType?: Maybe<TalkType>;
-  speakerId?: Maybe<Scalars["ID"]>;
 };
 
 export type QueryRoomArgs = {
@@ -63,6 +62,7 @@ export type Speaker = {
   biography?: Maybe<Scalars["String"]>;
   /** The URL of the user's upload avatar image. */
   avatar?: Maybe<Scalars["String"]>;
+  talks: Array<Talk>;
 };
 
 export type Talk = {

--- a/src/components/speaker/SpeakerDetails.generated.tsx
+++ b/src/components/speaker/SpeakerDetails.generated.tsx
@@ -15,8 +15,11 @@ export type SpeakerDetailsQuery = { readonly __typename?: "Query" } & {
     { readonly __typename?: "Speaker" } & Pick<
       Types.Speaker,
       "id" | "avatar" | "name" | "biography"
-    > &
-      SpeakerInfoFragment
+    > & {
+        readonly talks: ReadonlyArray<
+          { readonly __typename?: "Talk" } & Pick<Types.Talk, "id">
+        >;
+      } & SpeakerInfoFragment
   >;
 };
 
@@ -28,6 +31,9 @@ export const SpeakerDetailsDocument = gql`
       avatar
       name
       biography
+      talks {
+        id
+      }
     }
   }
   ${SpeakerInfoFragmentDoc}

--- a/src/components/speaker/SpeakerDetails.generated.tsx
+++ b/src/components/speaker/SpeakerDetails.generated.tsx
@@ -1,8 +1,10 @@
 import * as Types from "../../apollo/__generated__/types";
 
 import { SpeakerInfoFragment } from "./SpeakerInfo.generated";
+import { AgendaTalksListItemFragment } from "../agenda/AgendaTalksListItem.generated";
 import gql from "graphql-tag";
 import { SpeakerInfoFragmentDoc } from "./SpeakerInfo.generated";
+import { AgendaTalksListItemFragmentDoc } from "../agenda/AgendaTalksListItem.generated";
 import * as ApolloReactCommon from "@apollo/client";
 import * as ApolloReactHooks from "@apollo/client";
 
@@ -17,7 +19,8 @@ export type SpeakerDetailsQuery = { readonly __typename?: "Query" } & {
       "id" | "avatar" | "name" | "biography"
     > & {
         readonly talks: ReadonlyArray<
-          { readonly __typename?: "Talk" } & Pick<Types.Talk, "id">
+          { readonly __typename?: "Talk" } & Pick<Types.Talk, "id"> &
+            AgendaTalksListItemFragment
         >;
       } & SpeakerInfoFragment
   >;
@@ -33,10 +36,12 @@ export const SpeakerDetailsDocument = gql`
       biography
       talks {
         id
+        ...AgendaTalksListItem
       }
     }
   }
   ${SpeakerInfoFragmentDoc}
+  ${AgendaTalksListItemFragmentDoc}
 `;
 
 /**

--- a/src/components/speaker/SpeakerDetails.graphql
+++ b/src/components/speaker/SpeakerDetails.graphql
@@ -7,6 +7,7 @@ query SpeakerDetails($id: ID!) {
     biography
     talks {
       id
+      ...AgendaTalksListItem
     }
   }
 }

--- a/src/components/speaker/SpeakerDetails.graphql
+++ b/src/components/speaker/SpeakerDetails.graphql
@@ -5,5 +5,8 @@ query SpeakerDetails($id: ID!) {
     avatar
     name
     biography
+    talks {
+      id
+    }
   }
 }

--- a/src/components/speaker/SpeakerDetails.tsx
+++ b/src/components/speaker/SpeakerDetails.tsx
@@ -21,6 +21,8 @@ export const SpeakerDetails = ({ id }: { id: string }) => {
     return <p>Couldn't load this speaker...</p>;
   }
 
+  console.log(speaker);
+
   return (
     <div>
       <SpeakerDetailsHeading speaker={speaker} />

--- a/src/components/speaker/SpeakerDetails.tsx
+++ b/src/components/speaker/SpeakerDetails.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { css } from "emotion";
-
+import { AgendaTalksListItem } from "../agenda/AgendaTalksListItem";
 import {
   SpeakerDetailsQuery,
   useSpeakerDetailsQuery,
@@ -21,13 +21,23 @@ export const SpeakerDetails = ({ id }: { id: string }) => {
     return <p>Couldn't load this speaker...</p>;
   }
 
-  console.log(speaker);
+  const talks = speaker.talks;
 
   return (
     <div>
       <SpeakerDetailsHeading speaker={speaker} />
       <VSpace />
       <p>{speaker.biography}</p>
+      <h3> Talks </h3>
+      <div>
+        {talks.map((talk, index) => (
+          <AgendaTalksListItem
+            talkId={talk.id}
+            key={talk.id}
+            noTopBorder={index === 0}
+          />
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/pages/speaker/[id].tsx
+++ b/src/pages/speaker/[id].tsx
@@ -10,6 +10,7 @@ import { SpeakerDetails } from "../../components/speaker";
 export const SpeakerDetailsPage: NextPage = () => {
   const router = useRouter();
   const { id } = router.query;
+
   if (!id || typeof id !== "string") {
     return null;
   }

--- a/src/server/apollo/resolvers/Query.ts
+++ b/src/server/apollo/resolvers/Query.ts
@@ -7,11 +7,12 @@ export const Query: QueryResolvers = {
   talks: async (_root, args, { dataSources }) => {
     const talks = await dataSources.pretalx.getAllTalks();
 
-    const { roomId, talkType } = args;
+    const { roomId, talkType, speaker } = args;
     return filterTalks(talks, {
       day: args.day ? assertConferenceDay(args.day) : undefined,
       roomId,
       submissionType: talkType && talkTypeToSubmissionType(talkType),
+      speaker,
     });
   },
 

--- a/src/server/apollo/resolvers/Query.ts
+++ b/src/server/apollo/resolvers/Query.ts
@@ -7,12 +7,11 @@ export const Query: QueryResolvers = {
   talks: async (_root, args, { dataSources }) => {
     const talks = await dataSources.pretalx.getAllTalks();
 
-    const { roomId, talkType, speaker } = args;
+    const { roomId, talkType } = args;
     return filterTalks(talks, {
       day: args.day ? assertConferenceDay(args.day) : undefined,
       roomId,
       submissionType: talkType && talkTypeToSubmissionType(talkType),
-      speaker,
     });
   },
 

--- a/src/server/apollo/resolvers/Speaker.ts
+++ b/src/server/apollo/resolvers/Speaker.ts
@@ -1,3 +1,10 @@
 import { SpeakerResolvers } from "./__types__";
 
-export const Speaker: SpeakerResolvers = {};
+export const Speaker: SpeakerResolvers = {
+  talks: async (root, _args, { dataSources }) => {
+    const talks = await dataSources.pretalx.getAllTalks();
+    const result = talks.filter((talk) => talk.speakerIds.includes(root.id));
+
+    return result;
+  },
+};

--- a/src/server/apollo/resolvers/__types__.ts
+++ b/src/server/apollo/resolvers/__types__.ts
@@ -37,6 +37,7 @@ export type QueryTalksArgs = {
   day?: Maybe<Scalars["String"]>;
   roomId?: Maybe<Scalars["ID"]>;
   talkType?: Maybe<TalkType>;
+  speakerId?: Maybe<Scalars["ID"]>;
 };
 
 export type QueryRoomArgs = {

--- a/src/server/apollo/resolvers/__types__.ts
+++ b/src/server/apollo/resolvers/__types__.ts
@@ -37,7 +37,6 @@ export type QueryTalksArgs = {
   day?: Maybe<Scalars["String"]>;
   roomId?: Maybe<Scalars["ID"]>;
   talkType?: Maybe<TalkType>;
-  speakerId?: Maybe<Scalars["ID"]>;
 };
 
 export type QueryRoomArgs = {
@@ -74,6 +73,7 @@ export type Speaker = {
   readonly biography?: Maybe<Scalars["String"]>;
   /** The URL of the user's upload avatar image. */
   readonly avatar?: Maybe<Scalars["String"]>;
+  readonly talks: ReadonlyArray<Talk>;
 };
 
 export type Talk = {
@@ -307,6 +307,11 @@ export type SpeakerResolvers<
     ContextType
   >;
   avatar?: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
+  talks?: Resolver<
+    ReadonlyArray<ResolversTypes["Talk"]>,
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType>;
 };
 

--- a/src/server/apollo/typeDefs.ts
+++ b/src/server/apollo/typeDefs.ts
@@ -3,7 +3,7 @@ import { gql } from "apollo-server-micro";
 export const typeDefs = gql`
   type Query {
     talk(id: ID!): Talk
-    talks(day: String, roomId: ID, talkType: TalkType): [Talk!]!
+    talks(day: String, roomId: ID, talkType: TalkType, speakerId: ID): [Talk!]!
 
     room(id: ID!): Room
     rooms: [Room!]!

--- a/src/server/apollo/typeDefs.ts
+++ b/src/server/apollo/typeDefs.ts
@@ -3,7 +3,7 @@ import { gql } from "apollo-server-micro";
 export const typeDefs = gql`
   type Query {
     talk(id: ID!): Talk
-    talks(day: String, roomId: ID, talkType: TalkType, speakerId: ID): [Talk!]!
+    talks(day: String, roomId: ID, talkType: TalkType): [Talk!]!
 
     room(id: ID!): Room
     rooms: [Room!]!
@@ -42,6 +42,7 @@ export const typeDefs = gql`
     The URL of the user's upload avatar image.
     """
     avatar: String
+    talks: [Talk!]!
   }
 
   type Room {


### PR DESCRIPTION
- Added a list of the speaker's talks on their profile page as agenda list items
- Added talks resolver for Speaker in the GraphQL server to fetch the speaker's talks

The only problem is that the AgendaListItem component only displays the time of talk, and that might cause confusion, as it does not list the day of the talk. Furthermore, it could also be styled better.