### PR TITLE
Add stub routes (and nav links) for most pages

### DIFF
--- a/src/components/site/Nav.tsx
+++ b/src/components/site/Nav.tsx
@@ -13,6 +13,8 @@ export const Nav = () => {
       `}
     >
       <NavLink href={"/agenda"}>Agenda</NavLink>
+      <NavLink href={"/live"}>Live Schedule</NavLink>
+      <NavLink href={"/posters"}>Posters</NavLink>
     </nav>
   );
 };
@@ -61,7 +63,7 @@ const NavLink = ({ children, href, as }: NavLinkProps) => {
         <span
           className={css`
             display: block;
-            padding: 0.5rem;
+            padding: 1rem;
           `}
         >
           {children}

--- a/src/pages/api/talk/[id]/export.ts
+++ b/src/pages/api/talk/[id]/export.ts
@@ -1,0 +1,12 @@
+import { NextApiHandler } from "next";
+
+/**
+ * An API route to export a talk as a `.ics` file.
+ */
+const talkExportHandler: NextApiHandler = async (req, res) => {
+  res.status(404);
+  res.write("Not implemented");
+  res.end();
+};
+
+export default talkExportHandler;

--- a/src/pages/live.tsx
+++ b/src/pages/live.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+import { NextPage } from "next";
+import Error from "next/error";
+
+import { Page } from "../components/site";
+
+/**
+ * The "live overview" page for the app.
+ *
+ * This is the main view for the app during the conference. It's where users
+ * land when the log on.
+ *
+ * See https://github.com/JuliaCon/juliacon-webapp/issues/3 for details.
+ */
+const LivePage: NextPage = () => {
+  return (
+    <Page>
+      <Error statusCode={404} title={"Not implemented"} />
+    </Page>
+  );
+};
+
+export default LivePage;

--- a/src/pages/posters.tsx
+++ b/src/pages/posters.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { NextPage } from "next";
+import Error from "next/error";
+
+import { Page } from "../components/site";
+
+/**
+ * An overview of all of the poster submissions for the conference.
+ *
+ * See https://github.com/JuliaCon/juliacon-webapp/issues/2 for details.
+ */
+const PostersPage: NextPage = () => {
+  return (
+    <Page>
+      <Error statusCode={404} title={"Not implemented"} />
+    </Page>
+  );
+};
+
+export default PostersPage;

--- a/src/pages/talk/[id].tsx
+++ b/src/pages/talk/[id].tsx
@@ -4,6 +4,9 @@ import { useRouter } from "next/router";
 import { TalkDetails } from "../../components/TalkDetails";
 import React from "react";
 
+/**
+ * The details about a specific talk.
+ */
 export const TalkPage: NextPage = () => {
   const router = useRouter();
   const { id } = router.query;

--- a/src/pages/upload.tsx
+++ b/src/pages/upload.tsx
@@ -7,6 +7,11 @@ import { css } from "emotion";
 import Logo from "../assets/logo.svg";
 import { Center, VSpace } from "../components/layout";
 
+/**
+ * A page to allow presenters to upload their files. This is linked from the
+ * JuliaCon main site and just uploads files into an S3 bucket that the JuliaCon
+ * organizers have access to.
+ */
 const UploadPage: NextPage = () => {
   return (
     <div


### PR DESCRIPTION
This adds some "stub" code to give people entrypoints into the codebase for the routes that we (think) we ultimately want.