### PR TITLE
Fix word cloud pre-processing

### DIFF
--- a/data/viz_data_preprocess.jl
+++ b/data/viz_data_preprocess.jl
@@ -69,9 +69,11 @@ function get_corpus(data)
 
     # replace plurals and update the lexicon
     for doc in corpus
+        words = split(doc.text)
         for pair in pairs
-            doc.text = replace(doc.text, pair)
+            words = replace(words, pair)
         end
+        doc.text = join(words, " ")
     end
     update_lexicon!(corpus)
 

--- a/src/assets/vega/wordcloud_viz_data.json
+++ b/src/assets/vega/wordcloud_viz_data.json
@@ -10,14 +10,6 @@
   ]
  },
  {
-  "text": "discus design",
-  "count": 12,
-  "talks": [
-   4,
-   116
-  ]
- },
- {
   "text": "loop",
   "count": 20,
   "talks": [
@@ -75,13 +67,6 @@
   ]
  },
  {
-  "text": "glacier thicknes",
-  "count": 12,
-  "talks": [
-   107
-  ]
- },
- {
   "text": "layer",
   "count": 10,
   "talks": [
@@ -99,13 +84,6 @@
   "count": 12,
   "talks": [
    81
-  ]
- },
- {
-  "text": "visualstringdistance",
-  "count": 3,
-  "talks": [
-   108
   ]
  },
  {
@@ -127,6 +105,17 @@
   ]
  },
  {
+  "text": "sometimes",
+  "count": 6,
+  "talks": [
+   57,
+   79,
+   100,
+   111,
+   142
+  ]
+ },
+ {
   "text": "walk",
   "count": 3,
   "talks": [
@@ -141,6 +130,13 @@
   "talks": [
    59,
    104
+  ]
+ },
+ {
+  "text": "ice thickness",
+  "count": 20,
+  "talks": [
+   107
   ]
  },
  {
@@ -216,26 +212,10 @@
   ]
  },
  {
-  "text": "dge",
-  "count": 8,
+  "text": "generalizedlowrankmodels",
+  "count": 3,
   "talks": [
-   94
-  ]
- },
- {
-  "text": "thicknes estimation",
-  "count": 12,
-  "talks": [
-   107
-  ]
- },
- {
-  "text": "publicly available",
-  "count": 16,
-  "talks": [
-   38,
-   91,
-   127
+   29
   ]
  },
  {
@@ -246,6 +226,15 @@
    74,
    115,
    124
+  ]
+ },
+ {
+  "text": "publicly available",
+  "count": 16,
+  "talks": [
+   38,
+   91,
+   127
   ]
  },
  {
@@ -331,13 +320,6 @@
   ]
  },
  {
-  "text": "regular expresion",
-  "count": 16,
-  "talks": [
-   90
-  ]
- },
- {
   "text": "communities",
   "count": 6,
   "talks": [
@@ -379,13 +361,6 @@
   ]
  },
  {
-  "text": "clasroom",
-  "count": 5,
-  "talks": [
-   20
-  ]
- },
- {
   "text": "concatenation kronecker product",
   "count": 27,
   "talks": [
@@ -400,20 +375,10 @@
   ]
  },
  {
-  "text": "clasic",
-  "count": 5,
+  "text": "glacier thickness",
+  "count": 12,
   "talks": [
-   3,
-   5,
-   63,
-   136
-  ]
- },
- {
-  "text": "conditional neural proces",
-  "count": 27,
-  "talks": [
-   104
+   107
   ]
  },
  {
@@ -449,21 +414,6 @@
    101,
    125,
    130
-  ]
- },
- {
-  "text": "isue",
-  "count": 10,
-  "talks": [
-   17,
-   44,
-   48,
-   59,
-   67,
-   71,
-   82,
-   111,
-   132
   ]
  },
  {
@@ -831,6 +781,16 @@
   ]
  },
  {
+  "text": "message",
+  "count": 4,
+  "talks": [
+   5,
+   90,
+   117,
+   130
+  ]
+ },
+ {
   "text": "curriculum",
   "count": 19,
   "talks": [
@@ -865,6 +825,13 @@
   ]
  },
  {
+  "text": "pass nameddimsarray",
+  "count": 12,
+  "talks": [
+   117
+  ]
+ },
+ {
   "text": "algebra",
   "count": 11,
   "talks": [
@@ -878,17 +845,17 @@
   ]
  },
  {
+  "text": "symbolictensors",
+  "count": 3,
+  "talks": [
+   138
+  ]
+ },
+ {
   "text": "normal package",
   "count": 12,
   "talks": [
    150
-  ]
- },
- {
-  "text": "neuroscientist",
-  "count": 3,
-  "talks": [
-   136
   ]
  },
  {
@@ -960,27 +927,6 @@
    82,
    85,
    87
-  ]
- },
- {
-  "text": "discusion",
-  "count": 16,
-  "talks": [
-   27,
-   33,
-   37,
-   42,
-   49,
-   58,
-   71,
-   72,
-   81,
-   95,
-   112,
-   127,
-   137,
-   140,
-   147
   ]
  },
  {
@@ -1069,6 +1015,16 @@
   "talks": [
    82,
    89
+  ]
+ },
+ {
+  "text": "mass",
+  "count": 8,
+  "talks": [
+   107,
+   108,
+   119,
+   125
   ]
  },
  {
@@ -1399,16 +1355,6 @@
   ]
  },
  {
-  "text": "mesage",
-  "count": 4,
-  "talks": [
-   5,
-   90,
-   117,
-   130
-  ]
- },
- {
   "text": "mcmc",
   "count": 6,
   "talks": [
@@ -1426,10 +1372,27 @@
   ]
  },
  {
+  "text": "express",
+  "count": 5,
+  "talks": [
+   26,
+   32,
+   116,
+   148
+  ]
+ },
+ {
   "text": "registry",
   "count": 3,
   "talks": [
    108
+  ]
+ },
+ {
+  "text": "dsge",
+  "count": 14,
+  "talks": [
+   94
   ]
  },
  {
@@ -1465,19 +1428,20 @@
   ]
  },
  {
+  "text": "neural processes",
+  "count": 20,
+  "talks": [
+   36,
+   104
+  ]
+ },
+ {
   "text": "concrete",
   "count": 3,
   "talks": [
    55,
    73,
    146
-  ]
- },
- {
-  "text": "neural proces family",
-  "count": 27,
-  "talks": [
-   104
   ]
  },
  {
@@ -1520,13 +1484,6 @@
    91,
    101,
    130
-  ]
- },
- {
-  "text": "wireles speaker",
-  "count": 12,
-  "talks": [
-   76
   ]
  },
  {
@@ -1584,6 +1541,15 @@
   ]
  },
  {
+  "text": "lightgraphs",
+  "count": 5,
+  "talks": [
+   59,
+   115,
+   145
+  ]
+ },
+ {
   "text": "taking advantage",
   "count": 16,
   "talks": [
@@ -1591,13 +1557,6 @@
    76,
    116,
    152
-  ]
- },
- {
-  "text": "dgevar",
-  "count": 6,
-  "talks": [
-   94
   ]
  },
  {
@@ -1616,6 +1575,13 @@
   "talks": [
    79,
    150
+  ]
+ },
+ {
+  "text": "sheet thickness",
+  "count": 16,
+  "talks": [
+   119
   ]
  },
  {
@@ -1688,6 +1654,13 @@
   ]
  },
  {
+  "text": "neural process",
+  "count": 24,
+  "talks": [
+   104
+  ]
+ },
+ {
   "text": "dashboard",
   "count": 5,
   "talks": [
@@ -1704,19 +1677,19 @@
   ]
  },
  {
-  "text": "fragmentation",
-  "count": 3,
-  "talks": [
-   119
-  ]
- },
- {
   "text": "node",
   "count": 12,
   "talks": [
    81,
    110,
    132
+  ]
+ },
+ {
+  "text": "fragmentation",
+  "count": 3,
+  "talks": [
+   119
   ]
  },
  {
@@ -1853,16 +1826,6 @@
   ]
  },
  {
-  "text": "expres",
-  "count": 5,
-  "talks": [
-   26,
-   32,
-   116,
-   148
-  ]
- },
- {
   "text": "pre",
   "count": 4,
   "talks": [
@@ -1948,17 +1911,6 @@
   ]
  },
  {
-  "text": "gausian",
-  "count": 10,
-  "talks": [
-   24,
-   27,
-   35,
-   38,
-   146
-  ]
- },
- {
   "text": "discrete",
   "count": 9,
   "talks": [
@@ -2002,6 +1954,18 @@
    30,
    71,
    106
+  ]
+ },
+ {
+  "text": "kinds",
+  "count": 6,
+  "talks": [
+   25,
+   29,
+   51,
+   84,
+   116,
+   140
   ]
  },
  {
@@ -2085,6 +2049,13 @@
    37,
    55,
    67
+  ]
+ },
+ {
+  "text": "spaceship captain",
+  "count": 12,
+  "talks": [
+   46
   ]
  },
  {
@@ -2255,17 +2226,6 @@
   ]
  },
  {
-  "text": "sometime",
-  "count": 6,
-  "talks": [
-   57,
-   79,
-   100,
-   111,
-   142
-  ]
- },
- {
   "text": "flocking behaviour",
   "count": 12,
   "talks": [
@@ -2292,16 +2252,6 @@
   "count": 3,
   "talks": [
    26
-  ]
- },
- {
-  "text": "expresion",
-  "count": 9,
-  "talks": [
-   26,
-   67,
-   90,
-   138
   ]
  },
  {
@@ -2412,6 +2362,13 @@
   ]
  },
  {
+  "text": "dsgevar",
+  "count": 6,
+  "talks": [
+   94
+  ]
+ },
+ {
   "text": "pricing hedging",
   "count": 16,
   "talks": [
@@ -2495,6 +2452,18 @@
   ]
  },
  {
+  "text": "towards",
+  "count": 6,
+  "talks": [
+   37,
+   62,
+   70,
+   116,
+   142,
+   147
+  ]
+ },
+ {
   "text": "opportunity",
   "count": 6,
   "talks": [
@@ -2527,16 +2496,6 @@
   "count": 12,
   "talks": [
    82
-  ]
- },
- {
-  "text": "clases",
-  "count": 4,
-  "talks": [
-   3,
-   38,
-   57,
-   149
   ]
  },
  {
@@ -2790,6 +2749,15 @@
   ]
  },
  {
+  "text": "processed",
+  "count": 3,
+  "talks": [
+   51,
+   53,
+   125
+  ]
+ },
+ {
   "text": "collection",
   "count": 8,
   "talks": [
@@ -2801,6 +2769,15 @@
    110,
    112,
    130
+  ]
+ },
+ {
+  "text": "associated",
+  "count": 3,
+  "talks": [
+   1,
+   55,
+   128
   ]
  },
  {
@@ -3031,15 +3008,6 @@
   ]
  },
  {
-  "text": "pas",
-  "count": 5,
-  "talks": [
-   71,
-   105,
-   117
-  ]
- },
- {
   "text": "compensated algorithm",
   "count": 12,
   "talks": [
@@ -3092,12 +3060,14 @@
   ]
  },
  {
-  "text": "various package",
-  "count": 12,
+  "text": "discussing",
+  "count": 5,
   "talks": [
-   51,
-   135,
-   151
+   17,
+   71,
+   79,
+   93,
+   121
   ]
  },
  {
@@ -3110,6 +3080,15 @@
    130,
    146,
    152
+  ]
+ },
+ {
+  "text": "various package",
+  "count": 12,
+  "talks": [
+   51,
+   135,
+   151
   ]
  },
  {
@@ -3402,6 +3381,13 @@
   ]
  },
  {
+  "text": "classroom",
+  "count": 5,
+  "talks": [
+   20
+  ]
+ },
+ {
   "text": "gradient",
   "count": 16,
   "talks": [
@@ -3421,13 +3407,6 @@
   "count": 12,
   "talks": [
    84
-  ]
- },
- {
-  "text": "scoredrivenmodel",
-  "count": 3,
-  "talks": [
-   24
   ]
  },
  {
@@ -3593,21 +3572,6 @@
   ]
  },
  {
-  "text": "procesing",
-  "count": 21,
-  "talks": [
-   1,
-   26,
-   36,
-   51,
-   59,
-   75,
-   76,
-   130,
-   151
-  ]
- },
- {
   "text": "provided",
   "count": 7,
   "talks": [
@@ -3621,11 +3585,17 @@
   ]
  },
  {
-  "text": "poster sesion",
-  "count": 16,
+  "text": "access",
+  "count": 11,
   "talks": [
-   19,
-   87
+   20,
+   29,
+   71,
+   77,
+   111,
+   135,
+   136,
+   141
   ]
  },
  {
@@ -3946,15 +3916,6 @@
   ]
  },
  {
-  "text": "profesional",
-  "count": 3,
-  "talks": [
-   75,
-   114,
-   133
-  ]
- },
- {
   "text": "mean",
   "count": 13,
   "talks": [
@@ -3969,6 +3930,14 @@
    108,
    111,
    118
+  ]
+ },
+ {
+  "text": "language processing",
+  "count": 40,
+  "talks": [
+   75,
+   151
   ]
  },
  {
@@ -4026,6 +3995,13 @@
    88,
    130,
    149
+  ]
+ },
+ {
+  "text": "hydropowermodels",
+  "count": 3,
+  "talks": [
+   47
   ]
  },
  {
@@ -4266,12 +4242,12 @@
   ]
  },
  {
-  "text": "publicly",
-  "count": 4,
+  "text": "package discuss",
+  "count": 20,
   "talks": [
-   38,
-   91,
-   127
+   7,
+   34,
+   99
   ]
  },
  {
@@ -4319,6 +4295,15 @@
    26,
    41,
    119
+  ]
+ },
+ {
+  "text": "publicly",
+  "count": 4,
+  "talks": [
+   38,
+   91,
+   127
   ]
  },
  {
@@ -4523,6 +4508,15 @@
   ]
  },
  {
+  "text": "possibility",
+  "count": 3,
+  "talks": [
+   105,
+   117,
+   140
+  ]
+ },
+ {
   "text": "random",
   "count": 14,
   "talks": [
@@ -4538,20 +4532,20 @@
   ]
  },
  {
-  "text": "primarily",
-  "count": 3,
-  "talks": [
-   144,
-   149
-  ]
- },
- {
   "text": "developing package",
   "count": 12,
   "talks": [
    36,
    81,
    88
+  ]
+ },
+ {
+  "text": "primarily",
+  "count": 3,
+  "talks": [
+   144,
+   149
   ]
  },
  {
@@ -4655,22 +4649,6 @@
   ]
  },
  {
-  "text": "sesion",
-  "count": 16,
-  "talks": [
-   19,
-   20,
-   49,
-   58,
-   87,
-   93,
-   95,
-   98,
-   112,
-   144
-  ]
- },
- {
   "text": "front",
   "count": 4,
   "talks": [
@@ -4687,6 +4665,14 @@
    32,
    41,
    84
+  ]
+ },
+ {
+  "text": "massively scalable",
+  "count": 16,
+  "talks": [
+   91,
+   143
   ]
  },
  {
@@ -4953,6 +4939,13 @@
   ]
  },
  {
+  "text": "networkdynamics",
+  "count": 4,
+  "talks": [
+   145
+  ]
+ },
+ {
   "text": "stencil based",
   "count": 12,
   "talks": [
@@ -5086,19 +5079,73 @@
   ]
  },
  {
+  "text": "netherlands",
+  "count": 3,
+  "talks": [
+   19,
+   50
+  ]
+ },
+ {
+  "text": "discuss",
+  "count": 45,
+  "talks": [
+   2,
+   4,
+   5,
+   7,
+   9,
+   14,
+   31,
+   32,
+   33,
+   34,
+   36,
+   38,
+   43,
+   46,
+   47,
+   61,
+   67,
+   77,
+   85,
+   94,
+   96,
+   98,
+   99,
+   100,
+   101,
+   109,
+   110,
+   116,
+   121,
+   143,
+   144,
+   147,
+   151
+  ]
+ },
+ {
+  "text": "class",
+  "count": 11,
+  "talks": [
+   24,
+   35,
+   51,
+   61,
+   72,
+   85,
+   93,
+   104
+  ]
+ },
+ {
   "text": "shown",
   "count": 3,
   "talks": [
    8,
    119,
    140
-  ]
- },
- {
-  "text": "symbolictensor",
-  "count": 3,
-  "talks": [
-   138
   ]
  },
  {
@@ -5156,12 +5203,28 @@
   ]
  },
  {
-  "text": "reduction",
-  "count": 3,
+  "text": "process",
+  "count": 34,
   "talks": [
-   5,
-   100,
-   125
+   17,
+   26,
+   28,
+   35,
+   44,
+   47,
+   48,
+   50,
+   61,
+   79,
+   88,
+   95,
+   104,
+   105,
+   106,
+   131,
+   141,
+   146,
+   152
   ]
  },
  {
@@ -5175,11 +5238,20 @@
   ]
  },
  {
-  "text": "expresive",
-  "count": 3,
+  "text": "introduction",
+  "count": 12,
   "talks": [
-   90,
-   111
+   13,
+   24,
+   27,
+   71,
+   95,
+   104,
+   111,
+   114,
+   130,
+   137,
+   146
   ]
  },
  {
@@ -5233,20 +5305,12 @@
   ]
  },
  {
-  "text": "introduction",
-  "count": 12,
+  "text": "reduction",
+  "count": 3,
   "talks": [
-   13,
-   24,
-   27,
-   71,
-   95,
-   104,
-   111,
-   114,
-   130,
-   137,
-   146
+   5,
+   100,
+   125
   ]
  },
  {
@@ -5393,6 +5457,23 @@
   ]
  },
  {
+  "text": "signal processing",
+  "count": 12,
+  "talks": [
+   76,
+   130
+  ]
+ },
+ {
+  "text": "accompanied",
+  "count": 3,
+  "talks": [
+   58,
+   93,
+   119
+  ]
+ },
+ {
   "text": "value",
   "count": 16,
   "talks": [
@@ -5407,15 +5488,6 @@
    105,
    117,
    137
-  ]
- },
- {
-  "text": "accompanied",
-  "count": 3,
-  "talks": [
-   58,
-   93,
-   119
   ]
  },
  {
@@ -5446,15 +5518,13 @@
   ]
  },
  {
-  "text": "toward",
-  "count": 6,
+  "text": "package makes",
+  "count": 16,
   "talks": [
-   37,
-   62,
-   70,
-   116,
-   142,
-   147
+   26,
+   59,
+   135,
+   150
   ]
  },
  {
@@ -5475,23 +5545,6 @@
   "talks": [
    60,
    133
-  ]
- },
- {
-  "text": "package makes",
-  "count": 16,
-  "talks": [
-   26,
-   59,
-   135,
-   150
-  ]
- },
- {
-  "text": "linearmap",
-  "count": 4,
-  "talks": [
-   3
   ]
  },
  {
@@ -5524,6 +5577,23 @@
    14,
    38,
    147
+  ]
+ },
+ {
+  "text": "dsl",
+  "count": 6,
+  "talks": [
+   64,
+   71,
+   113,
+   147
+  ]
+ },
+ {
+  "text": "language processing technique",
+  "count": 27,
+  "talks": [
+   75
   ]
  },
  {
@@ -5582,11 +5652,10 @@
   ]
  },
  {
-  "text": "diagonal",
-  "count": 3,
+  "text": "thickness estimation model",
+  "count": 27,
   "talks": [
-   3,
-   152
+   107
   ]
  },
  {
@@ -5673,6 +5742,14 @@
    107,
    118,
    130
+  ]
+ },
+ {
+  "text": "diagonal",
+  "count": 3,
+  "talks": [
+   3,
+   152
   ]
  },
  {
@@ -5804,6 +5881,13 @@
   ]
  },
  {
+  "text": "kernelabstractions",
+  "count": 4,
+  "talks": [
+   142
+  ]
+ },
+ {
   "text": "conditional",
   "count": 5,
   "talks": [
@@ -5823,6 +5907,27 @@
   "count": 5,
   "talks": [
    86
+  ]
+ },
+ {
+  "text": "discussion",
+  "count": 16,
+  "talks": [
+   27,
+   33,
+   37,
+   42,
+   49,
+   58,
+   71,
+   72,
+   81,
+   95,
+   112,
+   127,
+   137,
+   140,
+   147
   ]
  },
  {
@@ -6025,12 +6130,18 @@
   ]
  },
  {
-  "text": "package discus",
-  "count": 20,
+  "text": "processing",
+  "count": 21,
   "talks": [
-   7,
-   34,
-   99
+   1,
+   26,
+   36,
+   51,
+   59,
+   75,
+   76,
+   130,
+   151
   ]
  },
  {
@@ -6184,14 +6295,6 @@
   ]
  },
  {
-  "text": "masively scalable",
-  "count": 16,
-  "talks": [
-   91,
-   143
-  ]
- },
- {
   "text": "special",
   "count": 4,
   "talks": [
@@ -6235,6 +6338,15 @@
   "count": 28,
   "talks": [
    95
+  ]
+ },
+ {
+  "text": "gaussian processes",
+  "count": 20,
+  "talks": [
+   35,
+   38,
+   146
   ]
  },
  {
@@ -6407,6 +6519,14 @@
   ]
  },
  {
+  "text": "expressive",
+  "count": 3,
+  "talks": [
+   90,
+   111
+  ]
+ },
+ {
   "text": "strength",
   "count": 4,
   "talks": [
@@ -6442,13 +6562,6 @@
   "talks": [
    48,
    87
-  ]
- },
- {
-  "text": "ecologicalnetwork",
-  "count": 3,
-  "talks": [
-   55
   ]
  },
  {
@@ -6601,16 +6714,6 @@
   "count": 16,
   "talks": [
    104
-  ]
- },
- {
-  "text": "mas",
-  "count": 8,
-  "talks": [
-   107,
-   108,
-   119,
-   125
   ]
  },
  {
@@ -6790,6 +6893,16 @@
   ]
  },
  {
+  "text": "regression",
+  "count": 4,
+  "talks": [
+   27,
+   32,
+   35,
+   38
+  ]
+ },
+ {
   "text": "design choice",
   "count": 24,
   "talks": [
@@ -6827,20 +6940,20 @@
   ]
  },
  {
-  "text": "addreses",
-  "count": 4,
+  "text": "session",
+  "count": 20,
   "talks": [
-   47,
-   48,
+   15,
+   19,
+   20,
+   49,
+   58,
+   87,
+   93,
    95,
-   136
-  ]
- },
- {
-  "text": "proces family",
-  "count": 12,
-  "talks": [
-   104
+   98,
+   112,
+   144
   ]
  },
  {
@@ -6962,6 +7075,19 @@
   ]
  },
  {
+  "text": "differentialequations",
+  "count": 14,
+  "talks": [
+   31,
+   62,
+   88,
+   96,
+   97,
+   145,
+   147
+  ]
+ },
+ {
   "text": "kronecker",
   "count": 3,
   "talks": [
@@ -7044,16 +7170,6 @@
    41,
    44,
    51
-  ]
- },
- {
-  "text": "lesons learned",
-  "count": 16,
-  "talks": [
-   33,
-   44,
-   88,
-   115
   ]
  },
  {
@@ -7187,13 +7303,6 @@
   ]
  },
  {
-  "text": "spacehip captain",
-  "count": 12,
-  "talks": [
-   46
-  ]
- },
- {
   "text": "learning",
   "count": 75,
   "talks": [
@@ -7232,6 +7341,16 @@
    90,
    115,
    133
+  ]
+ },
+ {
+  "text": "lessons",
+  "count": 4,
+  "talks": [
+   33,
+   44,
+   88,
+   115
   ]
  },
  {
@@ -7388,20 +7507,6 @@
   ]
  },
  {
-  "text": "autoregresive",
-  "count": 3,
-  "talks": [
-   24
-  ]
- },
- {
-  "text": "neuralproceses",
-  "count": 5,
-  "talks": [
-   104
-  ]
- },
- {
   "text": "anticipated",
   "count": 4,
   "talks": [
@@ -7425,13 +7530,6 @@
   "talks": [
    36,
    136
-  ]
- },
- {
-  "text": "generalizedlowrankmodel",
-  "count": 3,
-  "talks": [
-   29
   ]
  },
  {
@@ -7573,14 +7671,6 @@
   ]
  },
  {
-  "text": "natural language procesing",
-  "count": 90,
-  "talks": [
-   75,
-   151
-  ]
- },
- {
   "text": "advanced feature",
   "count": 12,
   "talks": [
@@ -7714,14 +7804,6 @@
    37,
    105,
    137
-  ]
- },
- {
-  "text": "clas model",
-  "count": 16,
-  "talks": [
-   24,
-   104
   ]
  },
  {
@@ -8061,16 +8143,6 @@
   ]
  },
  {
-  "text": "lesons",
-  "count": 4,
-  "talks": [
-   33,
-   44,
-   88,
-   115
-  ]
- },
- {
   "text": "extensive",
   "count": 5,
   "talks": [
@@ -8102,19 +8174,6 @@
   "talks": [
    19,
    152
-  ]
- },
- {
-  "text": "differentialequation",
-  "count": 14,
-  "talks": [
-   31,
-   62,
-   88,
-   96,
-   97,
-   145,
-   147
   ]
  },
  {
@@ -8163,15 +8222,6 @@
    73,
    91,
    94
-  ]
- },
- {
-  "text": "posibility",
-  "count": 3,
-  "talks": [
-   105,
-   117,
-   140
   ]
  },
  {
@@ -8337,11 +8387,10 @@
   ]
  },
  {
-  "text": "proceses gp",
-  "count": 12,
+  "text": "statsmodels",
+  "count": 3,
   "talks": [
-   35,
-   38
+   44
   ]
  },
  {
@@ -8750,6 +8799,16 @@
   ]
  },
  {
+  "text": "lessons learned",
+  "count": 16,
+  "talks": [
+   33,
+   44,
+   88,
+   115
+  ]
+ },
+ {
   "text": "parallel implementation",
   "count": 12,
   "talks": [
@@ -8782,13 +8841,6 @@
    63,
    70,
    105
-  ]
- },
- {
-  "text": "spacehip",
-  "count": 3,
-  "talks": [
-   46
   ]
  },
  {
@@ -8880,6 +8932,13 @@
    136,
    137,
    150
+  ]
+ },
+ {
+  "text": "spaceship",
+  "count": 3,
+  "talks": [
+   46
   ]
  },
  {
@@ -8998,24 +9057,6 @@
   ]
  },
  {
-  "text": "gausian proceses gp",
-  "count": 27,
-  "talks": [
-   35,
-   38
-  ]
- },
- {
-  "text": "finite",
-  "count": 6,
-  "talks": [
-   41,
-   93,
-   111,
-   143
-  ]
- },
- {
   "text": "pure",
   "count": 10,
   "talks": [
@@ -9026,6 +9067,16 @@
    130,
    133,
    138
+  ]
+ },
+ {
+  "text": "finite",
+  "count": 6,
+  "talks": [
+   41,
+   93,
+   111,
+   143
   ]
  },
  {
@@ -9046,6 +9097,14 @@
    26,
    90,
    128
+  ]
+ },
+ {
+  "text": "assistant",
+  "count": 3,
+  "talks": [
+   45,
+   80
   ]
  },
  {
@@ -9077,6 +9136,13 @@
   ]
  },
  {
+  "text": "regular expression",
+  "count": 16,
+  "talks": [
+   90
+  ]
+ },
+ {
   "text": "dimensional",
   "count": 9,
   "talks": [
@@ -9101,10 +9167,13 @@
   ]
  },
  {
-  "text": "manifoldbase",
-  "count": 3,
+  "text": "addresses",
+  "count": 4,
   "talks": [
-   73
+   47,
+   48,
+   95,
+   136
   ]
  },
  {
@@ -9128,6 +9197,16 @@
    142,
    145,
    151
+  ]
+ },
+ {
+  "text": "success",
+  "count": 4,
+  "talks": [
+   8,
+   44,
+   56,
+   101
   ]
  },
  {
@@ -9526,18 +9605,6 @@
   ]
  },
  {
-  "text": "kind",
-  "count": 6,
-  "talks": [
-   25,
-   29,
-   51,
-   84,
-   116,
-   140
-  ]
- },
- {
   "text": "numf",
   "count": 3,
   "talks": [
@@ -9568,12 +9635,11 @@
   ]
  },
  {
-  "text": "role",
-  "count": 3,
+  "text": "massively",
+  "count": 4,
   "talks": [
-   18,
-   81,
-   119
+   91,
+   143
   ]
  },
  {
@@ -9582,6 +9648,15 @@
   "talks": [
    29,
    53
+  ]
+ },
+ {
+  "text": "role",
+  "count": 3,
+  "talks": [
+   18,
+   81,
+   119
   ]
  },
  {
@@ -9733,6 +9808,14 @@
   ]
  },
  {
+  "text": "processes gp",
+  "count": 12,
+  "talks": [
+   35,
+   38
+  ]
+ },
+ {
   "text": "gpu cpu",
   "count": 12,
   "talks": [
@@ -9789,6 +9872,13 @@
   ]
  },
  {
+  "text": "process family",
+  "count": 12,
+  "talks": [
+   104
+  ]
+ },
+ {
   "text": "identified",
   "count": 3,
   "talks": [
@@ -9823,6 +9913,13 @@
    135,
    136,
    149
+  ]
+ },
+ {
+  "text": "autoregressive",
+  "count": 3,
+  "talks": [
+   24
   ]
  },
  {
@@ -9959,6 +10056,14 @@
   ]
  },
  {
+  "text": "gaussian processes gp",
+  "count": 27,
+  "talks": [
+   35,
+   38
+  ]
+ },
+ {
   "text": "instead",
   "count": 7,
   "talks": [
@@ -9986,16 +10091,6 @@
    30,
    91,
    130
-  ]
- },
- {
-  "text": "ases",
-  "count": 5,
-  "talks": [
-   47,
-   94,
-   127,
-   143
   ]
  },
  {
@@ -10073,42 +10168,11 @@
   ]
  },
  {
-  "text": "discus",
-  "count": 45,
+  "text": "class model",
+  "count": 16,
   "talks": [
-   2,
-   4,
-   5,
-   7,
-   9,
-   14,
-   31,
-   32,
-   33,
-   34,
-   36,
-   38,
-   43,
-   46,
-   47,
-   61,
-   67,
-   77,
-   85,
-   94,
-   96,
-   98,
-   99,
-   100,
-   101,
-   109,
-   110,
-   116,
-   121,
-   143,
-   144,
-   147,
-   151
+   24,
+   104
   ]
  },
  {
@@ -10230,13 +10294,6 @@
   "count": 12,
   "talks": [
    130
-  ]
- },
- {
-  "text": "wireles",
-  "count": 3,
-  "talks": [
-   76
   ]
  },
  {
@@ -10376,14 +10433,6 @@
   ]
  },
  {
-  "text": "jserve",
-  "count": 3,
-  "talks": [
-   54,
-   153
-  ]
- },
- {
   "text": "focus",
   "count": 16,
   "talks": [
@@ -10426,14 +10475,6 @@
   ]
  },
  {
-  "text": "signal procesing",
-  "count": 12,
-  "talks": [
-   76,
-   130
-  ]
- },
- {
   "text": "accuracy",
   "count": 5,
   "talks": [
@@ -10450,11 +10491,21 @@
   ]
  },
  {
-  "text": "based approach",
-  "count": 12,
+  "text": "processes",
+  "count": 18,
   "talks": [
-   78,
-   115
+   35,
+   36,
+   38,
+   52,
+   59,
+   87,
+   104,
+   112,
+   116,
+   139,
+   143,
+   146
   ]
  },
  {
@@ -10464,6 +10515,14 @@
    24,
    108,
    125
+  ]
+ },
+ {
+  "text": "based approach",
+  "count": 12,
+  "talks": [
+   78,
+   115
   ]
  },
  {
@@ -10481,14 +10540,6 @@
    37,
    48,
    128
-  ]
- },
- {
-  "text": "masively scalable multi",
-  "count": 27,
-  "talks": [
-   91,
-   143
   ]
  },
  {
@@ -10576,24 +10627,6 @@
   ]
  },
  {
-  "text": "sesions",
-  "count": 4,
-  "talks": [
-   15,
-   49,
-   98
-  ]
- },
- {
-  "text": "expresed",
-  "count": 3,
-  "talks": [
-   26,
-   32,
-   51
-  ]
- },
- {
   "text": "runtime",
   "count": 6,
   "talks": [
@@ -10646,15 +10679,6 @@
    20,
    87,
    98
-  ]
- },
- {
-  "text": "procesed",
-  "count": 3,
-  "talks": [
-   51,
-   53,
-   125
   ]
  },
  {
@@ -10762,13 +10786,6 @@
   ]
  },
  {
-  "text": "thicknes profile",
-  "count": 16,
-  "talks": [
-   119
-  ]
- },
- {
   "text": "xml",
   "count": 4,
   "talks": [
@@ -10813,6 +10830,15 @@
   ]
  },
  {
+  "text": "progress",
+  "count": 3,
+  "talks": [
+   61,
+   94,
+   106
+  ]
+ },
+ {
   "text": "graph",
   "count": 38,
   "talks": [
@@ -10852,10 +10878,11 @@
   ]
  },
  {
-  "text": "networkdynamic",
-  "count": 4,
+  "text": "low precision",
+  "count": 12,
   "talks": [
-   145
+   29,
+   70
   ]
  },
  {
@@ -10878,14 +10905,6 @@
    131,
    147,
    149
-  ]
- },
- {
-  "text": "low precision",
-  "count": 12,
-  "talks": [
-   29,
-   70
   ]
  },
  {
@@ -11018,6 +11037,13 @@
   ]
  },
  {
+  "text": "wireless speaker",
+  "count": 12,
+  "talks": [
+   76
+  ]
+ },
+ {
   "text": "lot",
   "count": 7,
   "talks": [
@@ -11027,6 +11053,13 @@
    98,
    116,
    138,
+   146
+  ]
+ },
+ {
+  "text": "kernelfunctions",
+  "count": 3,
+  "talks": [
    146
   ]
  },
@@ -11381,16 +11414,6 @@
   ]
  },
  {
-  "text": "mising",
-  "count": 5,
-  "talks": [
-   29,
-   99,
-   114,
-   147
-  ]
- },
- {
   "text": "engage",
   "count": 3,
   "talks": [
@@ -11643,6 +11666,13 @@
   ]
  },
  {
+  "text": "neural process family",
+  "count": 27,
+  "talks": [
+   104
+  ]
+ },
+ {
   "text": "top",
   "count": 11,
   "talks": [
@@ -11678,38 +11708,12 @@
   ]
  },
  {
-  "text": "proceses",
-  "count": 18,
-  "talks": [
-   35,
-   36,
-   38,
-   52,
-   59,
-   87,
-   104,
-   112,
-   116,
-   139,
-   143,
-   146
-  ]
- },
- {
   "text": "rule",
   "count": 12,
   "talks": [
    19,
    103,
    111
-  ]
- },
- {
-  "text": "neural proceses",
-  "count": 20,
-  "talks": [
-   36,
-   104
   ]
  },
  {
@@ -11840,15 +11844,6 @@
   ]
  },
  {
-  "text": "progres",
-  "count": 3,
-  "talks": [
-   61,
-   94,
-   106
-  ]
- },
- {
   "text": "breaking",
   "count": 3,
   "talks": [
@@ -11881,20 +11876,6 @@
   ]
  },
  {
-  "text": "clas",
-  "count": 11,
-  "talks": [
-   24,
-   35,
-   51,
-   61,
-   72,
-   85,
-   93,
-   104
-  ]
- },
- {
   "text": "specialized",
   "count": 7,
   "talks": [
@@ -11920,14 +11901,10 @@
   ]
  },
  {
-  "text": "discusing",
-  "count": 5,
+  "text": "dynamicgrids",
+  "count": 3,
   "talks": [
-   17,
-   71,
-   79,
-   93,
-   121
+   103
   ]
  },
  {
@@ -11980,14 +11957,6 @@
    91,
    133,
    137
-  ]
- },
- {
-  "text": "netherland",
-  "count": 3,
-  "talks": [
-   19,
-   50
   ]
  },
  {
@@ -12046,15 +12015,6 @@
   ]
  },
  {
-  "text": "addresed",
-  "count": 4,
-  "talks": [
-   48,
-   74,
-   118
-  ]
- },
- {
   "text": "traditional",
   "count": 10,
   "talks": [
@@ -12082,6 +12042,28 @@
   ]
  },
  {
+  "text": "discussed",
+  "count": 10,
+  "talks": [
+   48,
+   59,
+   68,
+   90,
+   93,
+   95,
+   108,
+   141,
+   149
+  ]
+ },
+ {
+  "text": "manifoldsbase",
+  "count": 3,
+  "talks": [
+   73
+  ]
+ },
+ {
   "text": "doesn",
   "count": 5,
   "talks": [
@@ -12103,6 +12085,13 @@
    127,
    136,
    152
+  ]
+ },
+ {
+  "text": "neuralprocesses",
+  "count": 5,
+  "talks": [
+   104
   ]
  },
  {
@@ -12243,19 +12232,17 @@
   ]
  },
  {
+  "text": "conditional neural process",
+  "count": 27,
+  "talks": [
+   104
+  ]
+ },
+ {
   "text": "manpower",
   "count": 5,
   "talks": [
    8
-  ]
- },
- {
-  "text": "vectorization",
-  "count": 4,
-  "talks": [
-   71,
-   82,
-   100
   ]
  },
  {
@@ -12269,11 +12256,12 @@
   ]
  },
  {
-  "text": "comparative",
-  "count": 3,
+  "text": "vectorization",
+  "count": 4,
   "talks": [
-   43,
-   130
+   71,
+   82,
+   100
   ]
  },
  {
@@ -12283,6 +12271,14 @@
    82,
    90,
    105
+  ]
+ },
+ {
+  "text": "comparative",
+  "count": 3,
+  "talks": [
+   43,
+   130
   ]
  },
  {
@@ -12564,13 +12560,6 @@
   ]
  },
  {
-  "text": "spacehip captain name",
-  "count": 27,
-  "talks": [
-   46
-  ]
- },
- {
   "text": "parallelism",
   "count": 13,
   "talks": [
@@ -12583,14 +12572,6 @@
    91,
    100,
    147
-  ]
- },
- {
-  "text": "clasification",
-  "count": 4,
-  "talks": [
-   26,
-   140
   ]
  },
  {
@@ -12615,6 +12596,13 @@
    96,
    97,
    100
+  ]
+ },
+ {
+  "text": "linearmaps",
+  "count": 4,
+  "talks": [
+   3
   ]
  },
  {
@@ -12662,13 +12650,6 @@
    125,
    133,
    144
-  ]
- },
- {
-  "text": "language procesing technique",
-  "count": 27,
-  "talks": [
-   75
   ]
  },
  {
@@ -12945,15 +12926,6 @@
   "count": 27,
   "talks": [
    82
-  ]
- },
- {
-  "text": "accesible",
-  "count": 3,
-  "talks": [
-   49,
-   91,
-   134
   ]
  },
  {
@@ -13242,13 +13214,6 @@
   ]
  },
  {
-  "text": "ice thicknes",
-  "count": 20,
-  "talks": [
-   107
-  ]
- },
- {
   "text": "integration",
   "count": 19,
   "talks": [
@@ -13266,6 +13231,13 @@
    136,
    145,
    152
+  ]
+ },
+ {
+  "text": "processing technique",
+  "count": 12,
+  "talks": [
+   75
   ]
  },
  {
@@ -13316,10 +13288,10 @@
   ]
  },
  {
-  "text": "dges",
-  "count": 6,
+  "text": "qml",
+  "count": 8,
   "talks": [
-   94
+   7
   ]
  },
  {
@@ -13328,13 +13300,6 @@
   "talks": [
    31,
    147
-  ]
- },
- {
-  "text": "qml",
-  "count": 8,
-  "talks": [
-   7
   ]
  },
  {
@@ -13444,6 +13409,22 @@
   ]
  },
  {
+  "text": "accessible",
+  "count": 3,
+  "talks": [
+   49,
+   91,
+   134
+  ]
+ },
+ {
+  "text": "preprocessing",
+  "count": 3,
+  "talks": [
+   26
+  ]
+ },
+ {
   "text": "innovations",
   "count": 4,
   "talks": [
@@ -13513,6 +13494,14 @@
   "count": 16,
   "talks": [
    18
+  ]
+ },
+ {
+  "text": "thickness",
+  "count": 16,
+  "talks": [
+   107,
+   119
   ]
  },
  {
@@ -13805,10 +13794,14 @@
   ]
  },
  {
-  "text": "statsmodel",
-  "count": 3,
+  "text": "gaussian",
+  "count": 10,
   "talks": [
-   44
+   24,
+   27,
+   35,
+   38,
+   146
   ]
  },
  {
@@ -13835,10 +13828,10 @@
   ]
  },
  {
-  "text": "preprocesing",
+  "text": "spreadsheet",
   "count": 3,
   "talks": [
-   26
+   37
   ]
  },
  {
@@ -14098,13 +14091,6 @@
   ]
  },
  {
-  "text": "neural proces",
-  "count": 24,
-  "talks": [
-   104
-  ]
- },
- {
   "text": "mix",
   "count": 3,
   "talks": [
@@ -14158,6 +14144,16 @@
   ]
  },
  {
+  "text": "assess",
+  "count": 5,
+  "talks": [
+   47,
+   94,
+   127,
+   143
+  ]
+ },
+ {
   "text": "nameddimsarray",
   "count": 3,
   "talks": [
@@ -14174,6 +14170,15 @@
    73,
    87,
    115
+  ]
+ },
+ {
+  "text": "expressed",
+  "count": 3,
+  "talks": [
+   26,
+   32,
+   51
   ]
  },
  {
@@ -14303,6 +14308,14 @@
   "talks": [
    5,
    67
+  ]
+ },
+ {
+  "text": "natural language processing",
+  "count": 90,
+  "talks": [
+   75,
+   151
   ]
  },
  {
@@ -14459,6 +14472,15 @@
   ]
  },
  {
+  "text": "possibilities",
+  "count": 3,
+  "talks": [
+   66,
+   105,
+   125
+  ]
+ },
+ {
   "text": "time effort",
   "count": 12,
   "talks": [
@@ -14522,6 +14544,21 @@
   "talks": [
    86,
    98
+  ]
+ },
+ {
+  "text": "issue",
+  "count": 10,
+  "talks": [
+   17,
+   44,
+   48,
+   59,
+   67,
+   71,
+   82,
+   111,
+   132
   ]
  },
  {
@@ -14617,6 +14654,14 @@
    55,
    59,
    107
+  ]
+ },
+ {
+  "text": "jsserve",
+  "count": 3,
+  "talks": [
+   54,
+   153
   ]
  },
  {
@@ -14799,13 +14844,6 @@
    105,
    133,
    152
-  ]
- },
- {
-  "text": "augmentedgausianproceses",
-  "count": 3,
-  "talks": [
-   35
   ]
  },
  {
@@ -15083,31 +15121,6 @@
   ]
  },
  {
-  "text": "proces",
-  "count": 34,
-  "talks": [
-   17,
-   26,
-   28,
-   35,
-   44,
-   47,
-   48,
-   50,
-   61,
-   79,
-   88,
-   95,
-   104,
-   105,
-   106,
-   131,
-   141,
-   146,
-   152
-  ]
- },
- {
   "text": "machine learning task",
   "count": 27,
   "talks": [
@@ -15159,24 +15172,6 @@
   ]
  },
  {
-  "text": "widepread",
-  "count": 3,
-  "talks": [
-   36,
-   82,
-   134
-  ]
- },
- {
-  "text": "embedded",
-  "count": 3,
-  "talks": [
-   1,
-   59,
-   147
-  ]
- },
- {
   "text": "abstract",
   "count": 12,
   "talks": [
@@ -15192,11 +15187,19 @@
   ]
  },
  {
-  "text": "language procesing",
-  "count": 40,
+  "text": "embedded",
+  "count": 3,
   "talks": [
-   75,
-   151
+   1,
+   59,
+   147
+  ]
+ },
+ {
+  "text": "ecologicalnetworks",
+  "count": 3,
+  "talks": [
+   55
   ]
  },
  {
@@ -15242,19 +15245,23 @@
   ]
  },
  {
-  "text": "hydropowermodel",
-  "count": 3,
-  "talks": [
-   47
-  ]
- },
- {
   "text": "focuses",
   "count": 3,
   "talks": [
    33,
    51,
    131
+  ]
+ },
+ {
+  "text": "mpi",
+  "count": 11,
+  "talks": [
+   5,
+   43,
+   91,
+   143,
+   147
   ]
  },
  {
@@ -15278,17 +15285,6 @@
    25,
    32,
    145
-  ]
- },
- {
-  "text": "mpi",
-  "count": 11,
-  "talks": [
-   5,
-   43,
-   91,
-   143,
-   147
   ]
  },
  {
@@ -15357,6 +15353,14 @@
    63,
    66,
    77
+  ]
+ },
+ {
+  "text": "classification",
+  "count": 4,
+  "talks": [
+   26,
+   140
   ]
  },
  {
@@ -15459,20 +15463,10 @@
   ]
  },
  {
-  "text": "gausian proceses",
-  "count": 20,
+  "text": "thickness estimation",
+  "count": 12,
   "talks": [
-   35,
-   38,
-   146
-  ]
- },
- {
-  "text": "webites",
-  "count": 3,
-  "talks": [
-   54,
-   75
+   107
   ]
  },
  {
@@ -15788,17 +15782,12 @@
   ]
  },
  {
-  "text": "acces",
-  "count": 11,
+  "text": "transition",
+  "count": 4,
   "talks": [
-   20,
-   29,
-   71,
-   77,
-   111,
-   135,
-   136,
-   141
+   70,
+   81,
+   120
   ]
  },
  {
@@ -15826,15 +15815,6 @@
   "talks": [
    16,
    148
-  ]
- },
- {
-  "text": "transition",
-  "count": 4,
-  "talks": [
-   70,
-   81,
-   120
   ]
  },
  {
@@ -15978,14 +15958,6 @@
   ]
  },
  {
-  "text": "thicknes",
-  "count": 16,
-  "talks": [
-   107,
-   119
-  ]
- },
- {
   "text": "itensor",
   "count": 4,
   "talks": [
@@ -16019,6 +15991,13 @@
   "count": 12,
   "talks": [
    103
+  ]
+ },
+ {
+  "text": "augmentedgaussianprocesses",
+  "count": 3,
+  "talks": [
+   35
   ]
  },
  {
@@ -16152,6 +16131,15 @@
   ]
  },
  {
+  "text": "loss",
+  "count": 6,
+  "talks": [
+   78,
+   82,
+   109
+  ]
+ },
+ {
   "text": "thank",
   "count": 6,
   "talks": [
@@ -16171,6 +16159,16 @@
    70,
    125,
    152
+  ]
+ },
+ {
+  "text": "expression",
+  "count": 9,
+  "talks": [
+   26,
+   67,
+   90,
+   138
   ]
  },
  {
@@ -16221,16 +16219,6 @@
   "count": 16,
   "talks": [
    68
-  ]
- },
- {
-  "text": "succes",
-  "count": 4,
-  "talks": [
-   8,
-   44,
-   56,
-   101
   ]
  },
  {
@@ -16794,17 +16782,10 @@
   ]
  },
  {
-  "text": "text",
-  "count": 15,
+  "text": "wireless",
+  "count": 3,
   "talks": [
-   19,
-   29,
-   69,
-   75,
-   79,
-   121,
-   131,
-   148
+   76
   ]
  },
  {
@@ -16822,19 +16803,26 @@
   ]
  },
  {
+  "text": "text",
+  "count": 15,
+  "talks": [
+   19,
+   29,
+   69,
+   75,
+   79,
+   121,
+   131,
+   148
+  ]
+ },
+ {
   "text": "parallelization",
   "count": 4,
   "talks": [
    17,
    91,
    94
-  ]
- },
- {
-  "text": "applied theory",
-  "count": 12,
-  "talks": [
-   140
   ]
  },
  {
@@ -16869,6 +16857,23 @@
    106,
    111,
    121,
+   140
+  ]
+ },
+ {
+  "text": "classic",
+  "count": 5,
+  "talks": [
+   3,
+   5,
+   63,
+   136
+  ]
+ },
+ {
+  "text": "applied theory",
+  "count": 12,
+  "talks": [
    140
   ]
  },
@@ -16943,15 +16948,6 @@
   "count": 16,
   "talks": [
    95
-  ]
- },
- {
-  "text": "asociated",
-  "count": 3,
-  "talks": [
-   1,
-   55,
-   128
   ]
  },
  {
@@ -17140,14 +17136,6 @@
    143,
    148,
    150
-  ]
- },
- {
-  "text": "procesor",
-  "count": 5,
-  "talks": [
-   70,
-   100
   ]
  },
  {
@@ -17368,6 +17356,14 @@
   ]
  },
  {
+  "text": "loss function",
+  "count": 20,
+  "talks": [
+   78,
+   109
+  ]
+ },
+ {
   "text": "hydrothermal power system",
   "count": 27,
   "talks": [
@@ -17441,6 +17437,14 @@
    140,
    145,
    152
+  ]
+ },
+ {
+  "text": "poster session",
+  "count": 16,
+  "talks": [
+   19,
+   87
   ]
  },
  {
@@ -17529,13 +17533,6 @@
   "count": 16,
   "talks": [
    26
-  ]
- },
- {
-  "text": "dynamicgrid",
-  "count": 3,
-  "talks": [
-   103
   ]
  },
  {
@@ -17656,6 +17653,13 @@
   ]
  },
  {
+  "text": "thickness profile",
+  "count": 16,
+  "talks": [
+   119
+  ]
+ },
+ {
   "text": "tensor manipulation",
   "count": 12,
   "talks": [
@@ -17717,10 +17721,11 @@
   ]
  },
  {
-  "text": "thicknes estimation model",
+  "text": "massively scalable multi",
   "count": 27,
   "talks": [
-   107
+   91,
+   143
   ]
  },
  {
@@ -17843,11 +17848,27 @@
   ]
  },
  {
+  "text": "processor",
+  "count": 7,
+  "talks": [
+   70,
+   100,
+   152
+  ]
+ },
+ {
   "text": "machine learning package",
   "count": 27,
   "talks": [
    75,
    117
+  ]
+ },
+ {
+  "text": "visualstringdistances",
+  "count": 3,
+  "talks": [
+   108
   ]
  },
  {
@@ -17867,15 +17888,6 @@
    58,
    89,
    112
-  ]
- },
- {
-  "text": "posibilities",
-  "count": 3,
-  "talks": [
-   66,
-   105,
-   125
   ]
  },
  {
@@ -17952,10 +17964,12 @@
   ]
  },
  {
-  "text": "blockchain",
-  "count": 4,
+  "text": "professional",
+  "count": 3,
   "talks": [
-   95
+   75,
+   114,
+   133
   ]
  },
  {
@@ -17970,10 +17984,35 @@
   ]
  },
  {
+  "text": "pass",
+  "count": 5,
+  "talks": [
+   71,
+   105,
+   117
+  ]
+ },
+ {
+  "text": "discuss challenge",
+  "count": 12,
+  "talks": [
+   2,
+   43,
+   110
+  ]
+ },
+ {
   "text": "manifold",
   "count": 26,
   "talks": [
    73
+  ]
+ },
+ {
+  "text": "blockchain",
+  "count": 4,
+  "talks": [
+   95
   ]
  },
  {
@@ -18236,14 +18275,6 @@
   ]
  },
  {
-  "text": "los function",
-  "count": 20,
-  "talks": [
-   78,
-   109
-  ]
- },
- {
   "text": "perspective",
   "count": 10,
   "talks": [
@@ -18345,10 +18376,13 @@
   ]
  },
  {
-  "text": "procesing technique",
-  "count": 12,
+  "text": "classes",
+  "count": 4,
   "talks": [
-   75
+   3,
+   38,
+   57,
+   149
   ]
  },
  {
@@ -18390,13 +18424,6 @@
   ]
  },
  {
-  "text": "sheet thicknes",
-  "count": 16,
-  "talks": [
-   119
-  ]
- },
- {
   "text": "framework",
   "count": 39,
   "talks": [
@@ -18422,15 +18449,6 @@
    143,
    146,
    148
-  ]
- },
- {
-  "text": "regresion",
-  "count": 3,
-  "talks": [
-   27,
-   35,
-   38
   ]
  },
  {
@@ -18591,12 +18609,12 @@
   ]
  },
  {
-  "text": "los",
-  "count": 6,
+  "text": "widespread",
+  "count": 3,
   "talks": [
-   78,
+   36,
    82,
-   109
+   134
   ]
  },
  {
@@ -18700,15 +18718,6 @@
   ]
  },
  {
-  "text": "discus challenge",
-  "count": 12,
-  "talks": [
-   2,
-   43,
-   110
-  ]
- },
- {
   "text": "entire",
   "count": 6,
   "talks": [
@@ -18769,6 +18778,15 @@
   ]
  },
  {
+  "text": "addressed",
+  "count": 4,
+  "talks": [
+   48,
+   74,
+   118
+  ]
+ },
+ {
   "text": "expenditure",
   "count": 3,
   "talks": [
@@ -18802,6 +18820,14 @@
    63,
    91,
    143
+  ]
+ },
+ {
+  "text": "discuss design",
+  "count": 12,
+  "talks": [
+   4,
+   116
   ]
  },
  {
@@ -18842,15 +18868,6 @@
    116,
    134,
    141
-  ]
- },
- {
-  "text": "lightgraph",
-  "count": 5,
-  "talks": [
-   59,
-   115,
-   145
   ]
  },
  {
@@ -18969,13 +18986,6 @@
    125,
    130,
    132
-  ]
- },
- {
-  "text": "kernelabstraction",
-  "count": 4,
-  "talks": [
-   142
   ]
  },
  {
@@ -19237,6 +19247,13 @@
   ]
  },
  {
+  "text": "scoredrivenmodels",
+  "count": 3,
+  "talks": [
+   24
+  ]
+ },
+ {
   "text": "presentation",
   "count": 15,
   "talks": [
@@ -19285,6 +19302,16 @@
   "count": 16,
   "talks": [
    25
+  ]
+ },
+ {
+  "text": "assumption",
+  "count": 7,
+  "talks": [
+   30,
+   55,
+   84,
+   115
   ]
  },
  {
@@ -19506,16 +19533,6 @@
   ]
  },
  {
-  "text": "asumption",
-  "count": 7,
-  "talks": [
-   30,
-   55,
-   84,
-   115
-  ]
- },
- {
   "text": "label",
   "count": 11,
   "talks": [
@@ -19602,6 +19619,13 @@
   ]
  },
  {
+  "text": "chainrules",
+  "count": 9,
+  "talks": [
+   111
+  ]
+ },
+ {
   "text": "line",
   "count": 4,
   "talks": [
@@ -19684,14 +19708,6 @@
    48,
    70,
    82
-  ]
- },
- {
-  "text": "asistant",
-  "count": 3,
-  "talks": [
-   45,
-   80
   ]
  },
  {
@@ -19813,13 +19829,6 @@
    9,
    31,
    120
-  ]
- },
- {
-  "text": "kernelfunction",
-  "count": 3,
-  "talks": [
-   146
   ]
  },
  {
@@ -20009,6 +20018,16 @@
   ]
  },
  {
+  "text": "missing",
+  "count": 5,
+  "talks": [
+   29,
+   99,
+   114,
+   147
+  ]
+ },
+ {
   "text": "statistical modeling",
   "count": 12,
   "talks": [
@@ -20068,6 +20087,13 @@
   ]
  },
  {
+  "text": "neuroscientists",
+  "count": 3,
+  "talks": [
+   136
+  ]
+ },
+ {
   "text": "clustering",
   "count": 4,
   "talks": [
@@ -20113,13 +20139,6 @@
    137,
    143,
    149
-  ]
- },
- {
-  "text": "pas nameddimsarray",
-  "count": 12,
-  "talks": [
-   117
   ]
  },
  {
@@ -20329,22 +20348,6 @@
   ]
  },
  {
-  "text": "discused",
-  "count": 11,
-  "talks": [
-   28,
-   48,
-   59,
-   68,
-   90,
-   93,
-   95,
-   108,
-   141,
-   149
-  ]
- },
- {
   "text": "conference",
   "count": 3,
   "talks": [
@@ -20406,6 +20409,21 @@
    111,
    114,
    116
+  ]
+ },
+ {
+  "text": "websites",
+  "count": 3,
+  "talks": [
+   54,
+   75
+  ]
+ },
+ {
+  "text": "spaceship captain name",
+  "count": 27,
+  "talks": [
+   46
   ]
  },
  {
@@ -20747,16 +20765,6 @@
   ]
  },
  {
-  "text": "dl",
-  "count": 6,
-  "talks": [
-   64,
-   71,
-   113,
-   147
-  ]
- },
- {
   "text": "domain task",
   "count": 12,
   "talks": [
@@ -20920,13 +20928,6 @@
   ]
  },
  {
-  "text": "chainrule",
-  "count": 9,
-  "talks": [
-   111
-  ]
- },
- {
   "text": "effort",
   "count": 16,
   "talks": [
@@ -21025,14 +21026,6 @@
    140,
    142,
    147
-  ]
- },
- {
-  "text": "masively",
-  "count": 4,
-  "talks": [
-   91,
-   143
   ]
  }
 ]


### PR DESCRIPTION
closes #52 

It turns out the pair `"ss" => "s"` snuck into the replacement dictionary and was causing a lot of typos in the word cloud.  The stemming now only replaces whole words instead of partials as well.