### PR TITLE
remove 'important links' link

### DIFF
--- a/src/components/site/Nav.tsx
+++ b/src/components/site/Nav.tsx
@@ -28,9 +28,6 @@ export const Nav = () => {
       <NavLink href={"https://juliacon.org/2022/tickets/"} external>
         Register
       </NavLink>
-      <NavLink href={"https://julialang.org/juliacon/"} external>
-        Important Links
-      </NavLink>
       <NavLink href={"/about"}>About</NavLink>
       <NavLink href={"/discord/join"}>Join Discord</NavLink>
       <NavLink href={"/agenda"}>Schedule</NavLink>


### PR DESCRIPTION
It looks bad. It's poor UX. It's inconsistent. It's pretty useless. There are plenty of links in the About page, any additional links should go there. Further, if the top menu bar has to scroll, then there are too many items in there -- not everything can be 'important' by definition. Or, in other words, if everything is important, nothing is. 