### PR TITLE
Update Invenia jobs link

### DIFF
--- a/src/pages/jobs.tsx
+++ b/src/pages/jobs.tsx
@@ -82,7 +82,7 @@ export const JobsPage: NextPage = () => {
               range of expertise, including machine learning, data science,
               power systems, and research software engineering. For details
               about current opportunities available, please visit{" "}
-              <ExternalLink href="joininvenia.com">
+              <ExternalLink href="https://jobs.lever.co/invenia">
                 joininvenia.com
               </ExternalLink>
               .


### PR DESCRIPTION
Current link is relative which needs to be fixed, and in addition, joininvenia.com has been moved permanently to this new address.