### PR TITLE
Fix RelationalAI job link

### DIFF
--- a/src/pages/jobs.tsx
+++ b/src/pages/jobs.tsx
@@ -32,7 +32,7 @@ export const JobsPage: NextPage = () => {
           <VSpace height={"0.5rem"} />
           <p>
             We have{" "}
-            <ExternalLink href="https://www.relational.ai/job-julia-ecosystem-engineer">
+            <ExternalLink href="https://boards.greenhouse.io/relationalai/jobs/4225730004">
               a job posting available
             </ExternalLink>{" "}
             for anyone interested in working with us on our integration with the


### PR DESCRIPTION
The current link 404s.

I assume this is the one they intended to link against: https://boards.greenhouse.io/relationalai/jobs/4225730004

We might be able to fix this instead on their side, but I don't know who to ping?